### PR TITLE
Add a setContentType method and fix readResponse to return entire response

### DIFF
--- a/RestClient.h
+++ b/RestClient.h
@@ -17,6 +17,9 @@ class RestClient {
                 const char* body, String* response);
     // Set a Request Header
     void setHeader(const char*);
+    // Set Content-Type Header
+    void setContentType(const char*);
+
     // GET path
     int get(const char*);
     // GET path and response
@@ -49,5 +52,5 @@ class RestClient {
     int port;
     int num_headers;
     const char* headers[10];
-    boolean contentTypeSet;
+	const char* contentType;
 };


### PR DESCRIPTION
Add a setContentType method and preserve the existing default value
Fix readResponse to return the whole of the response not just the first line
Fix: Once in the httpBody you don't need to keep looking for the blank line
