### PR TITLE
Use the generic Client interface instead of embedding Ethernet

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,64 +24,37 @@ You need to have the `Ethernet` library already included.
 #include "RestClient.h"
 ```
 
-### RestClient(host/ip, [port])
+### RestClient(host/ip, [port], Client)
 
 Constructor to create an RestClient object to make requests against.
 
 Use domain name and default to port 80:
 ```c++
-RestClient client = RestClient("arduino-http-lib-test.herokuapp.com");
+EthernetClient client
+RestClient client = RestClient("arduino-http-lib-test.herokuapp.com", client);
 ```
 
 Use a local IP and an explicit port:
 ```c++
-RestClient client = RestClient("192.168.1.50",5000);
+EthernetClient client
+RestClient client = RestClient("192.168.1.50", 5000, client);
 ```
+### Ethernet Setup
 
-### dhcp()
-
-Sets up `EthernetClient` with a mac address of `DEADBEEFFEED`. Returns `true` or `false` to indicate if setting up DHCP
-was successful or not
+You should configure an EthernetClient-compatible client and supply it to the library:
 
 ```c++
-  client.dhcp()
-```
-
-Note: you can have multiple RestClient objects but only need to call
-this once.
-
-Note: if you have multiple Arduinos on the same network, you'll need
-to give each one a different mac address.
-
-### begin(byte mac[])
-
-It just wraps the `EthernetClient` call to `begin` and DHCPs.
-Use this if you need to explicitly set the mac address.
-
-```c++
-  byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
-  if (client.begin(mac) == 0) {
-     Serial.println("Failed to configure Ethernet using DHCP");
-  }
-```
-
-### Manual Ethernet Setup
-
-You can skip the above methods and just configure the EthernetClient yourself:
-
-```c++
+EthernetClient client
+RestClient restClient("arduino-http-lib-test.herokuapp.com", client);
+void setup() {
   byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
   //the IP address for the shield:
   byte ip[] = { 192, 168, 2, 11 };
-  Ethernet.begin(mac,ip);
+	Ethernet.begin(mac, ip);
+}
 ```
 
-```c++
-  byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
-  Ethernet.begin(mac);
-```
-
-This is especially useful for debugging network connection issues.
+See the official documentation for [Ethernet](https://www.arduino.cc/en/Reference/Ethernet) for more information.
 
 ## RESTful methods
 

--- a/RestClient.h
+++ b/RestClient.h
@@ -1,24 +1,22 @@
 #include <Arduino.h>
-#include <SPI.h>
-#include <Ethernet.h>
+#include "Client.h"
 
 class RestClient {
 
   public:
-    RestClient(const char* host);
-    RestClient(const char* _host, int _port);
-
-    //Client Setup
-    bool dhcp();
-    int begin(byte*);
+    RestClient(const char* host, Client& client);
+    RestClient(const char* _host, int _port, Client& client);
 
     //Generic HTTP Request
     int request(const char* method, const char* path,
                 const char* body, String* response);
+
     // Set a Request Header
-    void setHeader(const char*);
+    RestClient& setHeader(const char*);
     // Set Content-Type Header
-    void setContentType(const char*);
+    RestClient& setContentType(const char*);
+
+    RestClient& setClient(Client& client);
 
     // GET path
     int get(const char*);
@@ -45,12 +43,12 @@ class RestClient {
     int del(const char*, const char*, String*);
 
   private:
-    EthernetClient client;
+    Client* client;
     int readResponse(String*);
     void write(const char*);
     const char* host;
     int port;
     int num_headers;
     const char* headers[10];
-	const char* contentType;
+    const char* contentType;
 };

--- a/examples/full_test_suite/full_test_suite.ino
+++ b/examples/full_test_suite/full_test_suite.ino
@@ -12,7 +12,10 @@
 int test_delay = 1000; //so we don't spam the API
 boolean describe_tests = true;
 
-RestClient client = RestClient("arduino-http-lib-test.herokuapp.com");
+const byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+EthernetClient ethclient;
+
+RestClient client = RestClient("arduino-http-lib-test.herokuapp.com", ethclient);
 //RestClient client  = RestClient("10.0.1.47",5000);
 
 
@@ -20,8 +23,10 @@ RestClient client = RestClient("arduino-http-lib-test.herokuapp.com");
 void setup() {
   Serial.begin(9600);
   // Connect via DHCP
-  Serial.println("connect to network");
-  client.dhcp();
+  if(Ethernet.begin(mac)) {
+    Serial.println("connected to network via DHCP");
+    Serial.print("IP received:"); Serial.println(Ethernet.localIP());
+  }
 /*
   //Can still fall back to manual config:
   byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };

--- a/examples/simple_GET/simple_GET.ino
+++ b/examples/simple_GET/simple_GET.ino
@@ -7,14 +7,19 @@
 #include <SPI.h>
 #include "RestClient.h"
 
-RestClient client = RestClient("arduino-http-lib-test.herokuapp.com");
+const byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+EthernetClient ethclient;
+
+RestClient client = RestClient("arduino-http-lib-test.herokuapp.com", ethclient);
 
 //Setup
 void setup() {
   Serial.begin(9600);
   // Connect via DHCP
-  Serial.println("connect to network");
-  client.dhcp();
+  if(Ethernet.begin(mac)) {
+    Serial.println("connected to network via DHCP");
+    Serial.print("IP received:"); Serial.println(Ethernet.localIP());
+  }
 /*
   // Can still fall back to manual config:
   byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };

--- a/examples/simple_POST/simple_POST.ino
+++ b/examples/simple_POST/simple_POST.ino
@@ -7,14 +7,19 @@
 #include <SPI.h>
 #include "RestClient.h"
 
-RestClient client = RestClient("arduino-http-lib-test.herokuapp.com");
+const byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };
+EthernetClient ethclient;
+
+RestClient client = RestClient("arduino-http-lib-test.herokuapp.com", ethclient);
 
 //Setup
 void setup() {
   Serial.begin(9600);
   // Connect via DHCP
-  Serial.println("connect to network");
-  client.dhcp();
+  if(Ethernet.begin(mac)) {
+    Serial.println("connected to network via DHCP");
+    Serial.print("IP received:"); Serial.println(Ethernet.localIP());
+  }
 /*
   // Can still fall back to manual config:
   byte mac[] = { 0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED };


### PR DESCRIPTION
This is a similar approach used by https://github.com/knolleary/pubsubclient.

I personally needed this feature to use https://github.com/UIPEthernet/UIPEthernet instead of the base `Ethernet` lib.