### PR TITLE
The content length was computed incorrectly

### DIFF
--- a/RestClient.cpp
+++ b/RestClient.cpp
@@ -130,7 +130,7 @@ int RestClient::request(const char* method, const char* path,
 
     if(body != NULL){
       char contentLength[30];
-      sprintf(contentLength, "Content-Length: %d\r\n", strlen(body));
+      sprintf(contentLength, "Content-Length: %d\r\n", strlen(body)+1); //The code below sends an extra CRLF
       write(contentLength);
 
 	  write("Content-Type: ");


### PR DESCRIPTION
I found that in certain conditions, the server would respond before the last CRLF was sent and then when the arduino tried put write it would receive a connection reset